### PR TITLE
Add initial "best practices" ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Kubernetes provider for Konveyor analyzer.
 
 The CLI version of the tool can be run to evaluate a single rule at a time. It accepts three parameters: `capability`, `initConfig`, and `conditionInfo`.
 
-* `capability` is the name of the capability needed to evaluate the rule. Currently, the implemented capabilities are `rego.expr` and `rego.module`.
+* `capability` is the name of the capability needed to evaluate the rule. Currently, the implemented capabilities are `rego_expr` and `rego_module`.
 * `initConfig` is a path to the provider init config stored as json.
 * `conditionInfo` is a path to a file containing parameters to the capability stored as json.
 
 Examples of the input files can be found in the `examples` directory. An example command invocation would be as follows:
 
 ```shell
-./bin/cli -initConfig initconfig.json -conditionInfo expression.json -capability rego.expr | jq
+./bin/cli -initConfig initconfig.json -conditionInfo expression.json -capability rego_expr | jq
 ```
 
 ## Code of Conduct

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor-ecosystem/k8s-provider
 
-go 1.21.5
+go 1.21
 
 require (
 	github.com/go-logr/logr v1.3.0

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -17,9 +17,8 @@ import (
 
 // Capabilities
 const (
-	CapabilityRegoModule     = "rego.module"
-	CapabilityRegoExpression = "rego.expr"
-	CapabilitySkopeo         = "skopeo"
+	CapabilityRegoModule     = "rego_module"
+	CapabilityRegoExpression = "rego_expr"
 )
 
 // K8sInitConfig is the provider init config with the k8s provider-specific fields unmarshalled.
@@ -107,9 +106,6 @@ func (r *K8s) Capabilities() (caps []libprovider.Capability) {
 		{
 			Name: CapabilityRegoModule,
 		},
-		{
-			Name: CapabilitySkopeo,
-		},
 	}
 	return
 }
@@ -121,9 +117,6 @@ func (r *K8s) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (r
 		resp, err = r.evaluateRegoExpression(ctx, conditionInfo)
 	case CapabilityRegoModule:
 		resp, err = r.evaluateRegoModule(ctx, conditionInfo)
-	case CapabilitySkopeo:
-		err = errors.New("not yet implemented")
-		return
 	}
 
 	return
@@ -137,7 +130,7 @@ func (r *K8s) GetDependenciesDAG(ctx context.Context) (dag map[uri.URI][]libprov
 	return
 }
 
-// evaluate a rego.expr rule
+// evaluate a rego_expr rule
 func (r *K8s) evaluateRegoExpression(ctx context.Context, conditionInfo []byte) (resp libprovider.ProviderEvaluateResponse, err error) {
 	condInfo := &ExpressionConditionInfo{}
 	err = json.Unmarshal(conditionInfo, condInfo)
@@ -162,7 +155,7 @@ func (r *K8s) evaluateRegoExpression(ctx context.Context, conditionInfo []byte) 
 	return
 }
 
-// evaluate a rego.module rule
+// evaluate a rego_module rule
 func (r *K8s) evaluateRegoModule(ctx context.Context, conditionInfo []byte) (resp libprovider.ProviderEvaluateResponse, err error) {
 	condInfo := &ModuleConditionInfo{}
 	err = json.Unmarshal(conditionInfo, condInfo)
@@ -194,6 +187,9 @@ func (r *K8s) interpretResultSet(results rego.ResultSet) (resp libprovider.Provi
 	incidents, ok := results[0].Bindings["incidents"].([]interface{})
 	if !ok {
 		err = errors.New("unknown result")
+		return
+	}
+	if len(incidents) == 0 {
 		return
 	}
 	resp.Matched = true

--- a/rules/bestpractices/00-availability.yaml
+++ b/rules/bestpractices/00-availability.yaml
@@ -1,0 +1,28 @@
+ruleID: low-replica-count
+effort: 1
+category: optional
+message: "Deployment has a low replica count"
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: item.spec.replicas < 2
+---
+ruleID: lonely-pod
+effort: 1
+category: optional
+message: "Pod does not have an OwnerReference. Pod lifecycle should be managed by a resource such as a Deployment to ensure availability."
+when:
+  k8s.rego_expr:
+    collection: pods
+    expression: not item.metadata.ownerReferences
+---
+ruleID: pod-anti-affinity
+effort: 1
+category: optional
+message: |
+  Deployment does not have pod anti-affinity rules set. Consider adding anti-affinity rules to ensure pods
+  are deployed on different nodes to improve availability in the event of a node failure.
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: not item.spec.template.spec.affinity.podAntiAffinity

--- a/rules/bestpractices/01-probes.yaml
+++ b/rules/bestpractices/01-probes.yaml
@@ -1,0 +1,33 @@
+---
+ruleID: no-readiness-probe
+effort: 1
+category: optional
+message: |
+  One or more containers in this deployment are missing a readiness probe. Without a readiness probe, the kubelet will
+  assume the container is ready for traffic as soon as it starts.
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; not container.readinessProbe
+---
+ruleID: no-liveness-probe
+effort: 1
+category: optional
+message: |
+  One or more containers in this deployment are missing a liveness probe. Liveness probes allow the kubelet to identify
+  when a running container is no longer responding correctly and needs to be restarted.
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; not container.livenessProbe
+---
+ruleID: duplicate-probes
+effort: 1
+category: optional
+message: |
+  One or more containers in this deployment appear to have identical liveness and readiness probes. Reusing the same
+  endpoint for both liveness and readiness probes diminishes their usefulness.
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; container.livenessProbe == container.readinessProbe

--- a/rules/bestpractices/02-resources.yaml
+++ b/rules/bestpractices/02-resources.yaml
@@ -1,0 +1,26 @@
+ruleID: missing-memory-limits
+effort: 1
+category: optional
+message: "Deployment containers are missing memory limits"
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; not container.resources.limits.memory
+---
+ruleID: missing-memory-requests
+effort: 1
+category: optional
+message: "Deployment containers are missing memory requests"
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; not container.resources.requests.memory
+---
+ruleID: missing-cpu-requests
+effort: 1
+category: optional
+message: "Deployment containers are missing CPU requests"
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; not container.resources.requests.cpu

--- a/rules/bestpractices/03-security.yaml
+++ b/rules/bestpractices/03-security.yaml
@@ -1,0 +1,17 @@
+ruleID: mount-secrets
+effort: 1
+category: optional
+message: "Mount Secrets as volumes, not environment variables to prevent them from leaking in the container start command."
+when:
+  k8s.rego_expr:
+    collection:
+    expression:
+---
+ruleID: avoid-privileged-containers
+effort: 1
+category: optional
+message: "Avoid running privileged containers if possible."
+when:
+  k8s.rego_expr:
+    collection: deployments
+    expression: some container in item.spec.template.spec.containers; container.securityContext.privileged

--- a/rules/bestpractices/ruleset.yaml
+++ b/rules/bestpractices/ruleset.yaml
@@ -1,0 +1,2 @@
+name: k8s Best Practices
+description:


### PR DESCRIPTION
* Adds initial (incomplete) set of best practices rules
* Fixes the capability names to avoid using `.` as it has a special significance in the ruleset syntax.
* Changes go mod version to 1.21 to avoid tooling problems with x.y.z version format.

Partially implements #3 